### PR TITLE
Reduce LFS big size when testing GCP

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -297,9 +297,7 @@ steps:
       - "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash"
       - apt-get install -y git-lfs
       - timeout -s ABRT 20m make test-gcp-migration
-      # Run TestGit in separated command, to prevent using all port range of the container
-      - timeout -s ABRT 20m make test-gcp#'[^T][^e][^s][^t][^G][^i][^t].+'
-      - timeout -s ABRT 20m make test-gcp#TestGit
+      - timeout -s ABRT 20m make test-gcp
     environment:
       GOPROXY: off
       TAGS: bindata

--- a/integrations/git_test.go
+++ b/integrations/git_test.go
@@ -26,12 +26,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
+var (
 	littleSize = 1024              // 1ko
 	bigSize    = 128 * 1024 * 1024 // 128Mo
 )
 
 func TestGit(t *testing.T) {
+	// Reduce big size for testing GCP, 128 Mo causes too many requests
+	// made to gcs fake server concurrently, CI container run out of resources.
+	if os.Getenv("STORAGE_EMULATOR_HOST") != "" {
+		bigSize = 4 * 1024 * 1024
+	}
 	onGiteaRun(t, testGit)
 }
 


### PR DESCRIPTION
GCS client calls are asynchronous, with large upload files, it causes
the CI container run out of resources quickly.
